### PR TITLE
Fix of gas used field inside websocket subscriptions

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -47,10 +47,10 @@ export default class RPCBroadcaster {
     }
 
     broadcastBlock(blockInfo: IndexedBlockInfo) {
-        let gasUsed = 0;
+        let gasUsed = "0x0";
 
         if (blockInfo.transactions.length > 0)
-            blockInfo.transactions[0]['@raw'].gasusedblock;
+            gasUsed = blockInfo.transactions[0]['@raw'].gasusedblock;
 
         const head = Object.assign({}, NEW_HEADS_TEMPLATE, {
             parentHash: `0x${blockInfo.parentHash}`,


### PR DESCRIPTION

Obviously, there is a typo in this part of the code, and the author wanted to overwrite gasUsed with a different value.